### PR TITLE
A8: SEO v1 (hreflang + sitemap + schema + OG) — closes #11

### DIFF
--- a/docs/canon/i18n_SEO.md
+++ b/docs/canon/i18n_SEO.md
@@ -1,21 +1,71 @@
-# i18n + SEO (Draft)
+# i18n + SEO — v1
 
-## 1. hreflang
-- Provide hreflang links for EN/FR/DE/ES/IT equivalents when available.
-- Include x-default pointing to EN (draft).
+date: 2026-03-02
 
-## 2. Canonical rules (draft)
-- Localized pages canonicalize to themselves when translation exists.
-m If locale page is a fallback to EN, define a consistent canonical strategy (TBD; avoid duplicate content penalties).
+Scope: SEO requirements per ТЗ: schema.org, sitemap.xml, hreflang, OpenGraph, Core Web Vitals. Supports locales EN/FR/DE/ES/IT.
 
-## 3. Sitemaps
-[- Generate sitemap entries for each locale and content type (recipes/articles/legal).
-m Option: per-locale sitemap index (TBD).
+---
 
-## 4. Structured data
-- schema.org Recipe for recipe pages
-- schema.org Article for article pages
-- OpenGraph/Twitter metadata for sharing
+## 1) URL & locale assumptions
+- Locale support: `en`, `fr`, `de`, `es`, `it`.
+- Locale routing strategy (path prefix vs domain) is an implementation choice; SEO rules below apply either way.
 
-## 5. Core Web Vitals
-- Optimize images, avoid layout shift, SSR where needed.
+---
+
+## 2) hreflang (MUST)
+- Provide `hreflang` links for each available locale variant of the same page (recipes/articles).
+- Include `x-default` pointing to EN.
+- Only include hreflang entries for locales that truly exist (do not point to fallback pages as “real translations”).
+
+---
+
+## 3) Canonical rules (MUST)
+- If a localized translation exists: page canonicalizes to **itself** (same locale URL).
+- If a locale view is a **fallback to EN** (translation missing):
+  - Prefer **not** to expose that as a separate indexable locale page.
+  - If it is exposed, ensure:
+    - canonical points to the EN page, and
+    - hreflang does **not** claim the missing locale as translated.
+
+> This is to prevent duplicate content indexing when fallback is used.
+
+---
+
+## 4) Sitemaps (MUST)
+- Provide `sitemap.xml` (or sitemap index) including:
+  - Home (`/`)
+  - Recipes catalog + recipe details
+  - Articles catalog + article details
+  - Legal pages (`/legal/*`)
+- Locale handling:
+  - Include URLs per locale **only if** the page is actually translated/published for that locale.
+  - Option: sitemap index with per-locale sitemaps (allowed; implementation choice).
+
+---
+
+## 5) Structured data (MUST)
+- Recipes: schema.org `Recipe`
+  - include: name, description, image, recipeIngredient, recipeInstructions, nutrition (calories/protein/fat/carbs) where available
+- Articles: schema.org `Article`
+  - include: headline, image, datePublished/dateModified, author/publisher if available
+
+---
+
+## 6) OpenGraph / Social metadata (MUST)
+- Per page: `og:title`, `og:description`, `og:image`, `og:url`
+- Twitter card tags (summary_large_image recommended)
+
+---
+
+## 7) Core Web Vitals (MUST)
+- Optimize images (responsive, lazy-load where appropriate)
+- Avoid layout shift (reserve space for images)
+- Use SSR where needed for indexable content
+- Cache and compress static assets
+
+---
+
+## 8) Robots & legal pages
+- Legal pages must exist: Privacy/Terms/Cookies/Disclaimer.
+- Indexing policy can be: index legal pages (usually OK) but avoid thin duplicates.
+


### PR DESCRIPTION
## Summary
Updates canon SEO doc to v1 per ТЗ: hreflang rules for EN/FR/DE/ES/IT, canonical strategy (including fallback handling), sitemap rules, schema.org for Recipe/Article, OpenGraph, and Core Web Vitals baseline.

## Files changed
- `docs/canon/i18n_SEO.md`

## Test plan (smoke)
- [ ] Open `docs/canon/i18n_SEO.md` and verify hreflang + sitemap + schema requirements are present
- [ ] Verify canonical rules mention fallback handling to avoid duplicate indexing

## Risks / edge cases
- Locale routing (prefix vs domain) is left to implementation; SEO rules must be applied consistently either way.

## Link to Issue
Closes #11