### PR TITLE
A9: Analytics v1 (MVP events + funnel + privacy) — closes #12

### DIFF
--- a/docs/canon/Analytics.md
+++ b/docs/canon/Analytics.md
@@ -1,27 +1,75 @@
-# Analytics (Draft) — MVP Event List
+# Analytics — v1 (MVP)
 
-## Principles
-- Avoid storing sensitive personal data.
-m Respect cookie consent and legal requirements (Privacy/Cookies pages).
+date: 2026-03-02
 
-## Common properties (draft)
-- user_role (guest/user/premium/admin)
-- locale
-- page_type
-- content_id (recipe/article)
-- referrer, utm params
-[- filters_applied, search_query_length (not raw query if privacy requires)
+Goal (ТЗ): measure activation (search → recipe → action), conversion to subscription, and retention D7/D30.
 
-## MVP events (draft)
-- page_view
-- search_performed (type: recipes|articles; query_length; filters)
-- filter_applied (type; values_count)
-- content_viewed (recipe|article; id)
-- favorite_added / favorite_removed (target_type; id)
-- shopping_list_opened
-- shopping_list_item_added / removed / checked
-- paywall_viewed (feature)
-- checkout_started
-- checkout_completed
-- subscription_status_changed (fret→premium, premium→canceled)
-- planner_opened (premium)
+---
+
+## 1) Privacy principles (must)
+- Do not store sensitive personal data in analytics events.
+- Respect cookie consent and legal requirements (Privacy/Cookies pages).
+- Avoid raw free-text where it may contain PII (e.g. search query). Use length or hashed/filtered approach if needed.
+
+---
+
+## 2) Common event properties (baseline)
+Recommended properties on all events:
+- `timestamp`
+- `user_role` (guest|user|premium|admin_editor)
+- `locale` (en|fr|de|es|it)
+- `page_path`
+- `page_type` (home|recipes|recipe|articles|article|account|planner|shopping_list|favorites|legal)
+- `session_id` (anonymous ok)
+- `referrer`, `utm_source`, `utm_medium`, `utm_campaign` (optional)
+
+Content-related:
+- `content_type` (recipe|article)
+- `content_id`
+- `slug` (optional)
+
+Search/filter:
+- `search_type` (recipes|articles)
+- `search_query_length` (int)
+- `filters_applied` (array of keys)
+- `filters_values_count` (int)
+
+Billing:
+- `paywall_feature` (planner|advanced_filters|export_sharing|nutrition_goals)
+- `plan_key` (premium_monthly)
+
+---
+
+## 3) MVP event taxonomy (required)
+### Navigation / page
+- `page_view`
+
+### Search & discovery
+- `search_performed` (search_type, search_query_length, filters_applied, filters_values_count)
+- `filter_applied` (filter_key, filter_values_count)
+
+### Content engagement
+- `content_viewed` (content_type, content_id)
+- `favorite_added` / `favorite_removed` (content_type, content_id)
+
+### Shopping list
+- `shopping_list_opened`
+- `shopping_list_item_added` / `shopping_list_item_removed`
+- `shopping_list_item_checked` (is_pantry)
+
+### Paywall & billing funnel
+- `paywall_viewed` (paywall_feature)
+- `checkout_started` (plan_key)
+- `checkout_completed` (plan_key)
+- `subscription_status_changed` (from_status, to_status)
+
+### Premium usage
+- `planner_opened` (requires premium)
+
+---
+
+## 4) MVP KPIs (how to compute)
+- Activation rate: users with `search_performed` + `content_viewed` + (`favorite_added` OR `shopping_list_item_added`) within first session/day.
+- Conversion: `checkout_completed` / `checkout_started` and `subscription_status_changed` to active.
+- Retention: D7/D30 returning users with any `page_view`.
+


### PR DESCRIPTION
## Summary
Updates canon analytics doc to v1 per ТЗ: privacy principles, common event properties, MVP event taxonomy covering search→content→action, paywall/checkout funnel, and KPI definitions (activation, conversion, retention).

## Files changed
- `docs/canon/Analytics.md`

## Test plan (smoke)
- [ ] Open `docs/canon/Analytics.md` and verify events cover recipes/articles, favorites, shopping list, paywall, checkout, planner
- [ ] Verify privacy guardrails (no sensitive data; avoid raw free-text)

## Risks / edge cases
- Search query privacy: implementation must avoid sending PII; doc recommends using length/filtered approach.

## Link to Issue
Closes #12