### PR TITLE
A10: TestPlan v1 (smoke + security baseline) — closes #13

### DIFF
--- a/docs/canon/TestPlan.md
+++ b/docs/canon/TestPlan.md
@@ -1,40 +1,94 @@
-# Test Plan (Draft) — MVP Smoke Checklist
+# Test Plan — v1 (MVP smoke + security)
 
-## 1. Public browsing (Guest)
-- Can view home, recipes catalog, articles catalog
-- Search by title works (recipes/articles)
-- Filters work (meal type; article rubric)
+date: 2026-03-02
 
-## 2. Auth / Account
-- Register / login / logout
-- Preferences: language change persists
+Scope: MVP smoke checklist aligned to ТЗ, including security, server-side premium gating, and Stripe webhook reliability.
 
-## 3. Favorites (User+)
+---
+
+## 1) Public browsing (Guest)
+- Home page loads (value proposition + CTAs)
+- Recipes catalog loads; cards show title/desc/KБЖУ
+- Articles catalog loads; cards show title/rubric
+- Search works:
+  - recipes by name
+  - articles by title
+- Filters work:
+  - recipes by meal type
+  - articles by rubric
+
+---
+
+## 2) Auth / Account
+- Register / login / logout works
+- Password storage: verify password is hashed (no plaintext in DB/logs)
+- Session/cookies:
+  - cookies marked Secure/HttpOnly where applicable
+  - session persists correctly across refresh
+- Preferences:
+  - language change persists (locale)
+  - onboarding fields exist (goal/preferences/allergies/language) (V1+)
+
+---
+
+## 3) Favorites (User+)
 - Add/remove favorite recipe
 - Add/remove favorite article
-- Favorites page shows items
+- Favorites page lists items (recipes + articles)
 
-## 4. Shopping list (User+)
-- From recipe → “Shopping list” adds ingredients to modal/list
-- Remove item / mark “have at home”
+---
+
+## 4) Shopping list (User+)
+- From recipe detail → “Shopping list” adds ingredients to modal/list with quantities
+- Remove item
+- Mark item as “have at home” (pantry)
 - Persist across refresh
 
-## 5. Premium gating (server-side)
-- Non-premium cannot access premium endpoints/features even if UI
-  is tampered
-- Premium user can access planner/advanced features
+---
 
-## 6. Stripe billing
-- Start checkout → complete → premium access granted
-- Customer Portal reachable for premium user
-- Webhook idempotency: re-sending same Stripe event does not duplicate side effects
+## 5) Premium gating (MUST be server-side)
+Negative tests (Guest/User without premium):
+- Cannot access premium pages/endpoints (e.g. `/planner`) even if UI is tampered (direct URL / API call)
+- Advanced filters / export/sharing endpoints return 403/401 as appropriate
 
-## 7. i18n + SEO sanity
+Positive tests (Premium):
+- Premium user can open planner (where implemented)
+- Premium-only features are available
+
+---
+
+## 6) Stripe billing (MVP)
+- Start checkout → complete → premium access granted (server-side)
+- Customer Portal session can be created for subscribed user
+- Webhook handler:
+  - verifies Stripe signature
+  - idempotency: re-sending the same Stripe `event.id` does not duplicate side effects
+  - retry-safe: simulated retry (same payload) converges to same state
+
+---
+
+## 7) Security quick checks (MVP baseline)
+- CSRF:
+  - state-changing endpoints protected (token/double-submit strategy; implementation detail)
+- XSS:
+  - user-controlled content is escaped/sanitized (especially article content rendering)
+- Access control:
+  - role checks enforced server-side for admin/editor endpoints
+- Rate limiting / abuse:
+  - basic protection is planned (implementation detail); confirm no obvious unauthenticated abuse endpoints in MVP
+
+---
+
+## 8) i18n + SEO sanity
 - Locale routing renders correct language shell
-- hreflang present (where applicable)
-- sitemap endpoint exists (if implemented in MVP)
+- hreflang present where translations exist
+- canonical tags present (especially when fallback is used)
+- sitemap endpoint exists (if included in MVP scope)
 - Basic OG tags present
 
-## 8. A11y quick pass
-- Keyboard navigation works for key flows
-- Basic contrast and focus visible (spot-check)
+---
+
+## 9) A11y quick pass
+- Keyboard navigation works for key flows (search, open recipe, add to favorites, open shopping list modal)
+- Focus visible and not trapped in modals
+- Form labels for auth fields are present (screen reader basics)


### PR DESCRIPTION
## Summary
Updates canon TestPlan to v1 per ТЗ: MVP smoke coverage for recipes/articles/favorites/shopping list, **server-side premium gating** negative tests, Stripe checkout+portal+webhooks (signature + idempotency), plus security quick checks (hashing, CSRF, XSS, access control).

## Files changed
- `docs/canon/TestPlan.md`

## Test plan (smoke)
- [ ] Open `docs/canon/TestPlan.md` and verify it includes premium gating server-side negative tests
- [ ] Verify Stripe webhook checks include signature verification + idempotency by event.id
- [ ] Verify security baseline items are listed (password hashing, CSRF, XSS)

## Risks / edge cases
- CSRF implementation detail is framework-specific; plan checks for protection presence rather than prescribing a mechanism.

## Link to Issue
Closes #13