### PR TITLE
S1-001: Stack lock ADRs (Netlify-only + DB/Prisma/Auth) — closes #23

### DIFF
--- a/docs/canon/ADR.md
+++ b/docs/canon/ADR.md
@@ -22,9 +22,28 @@ We will use **Netlify-only** hosting for:
 
 ---
 
-## Pending ADRs (not decided yet)
+## ADR-0002 — Stack lock for Sprint 1 (Netlify + Next.js + DB + Prisma + Auth)
+- Status: Accepted
+- Date: 2026-03-02
+
+### Context
+Sprint 1 requires an implementable end-to-end stack under the Netlify-only constraint. We need clear decisions for runtime, data storage, ORM/migrations, and authentication to unblock S1 implementation.
+
+### Decision
+For Sprint 1 we will use:
+- **Hosting/Runtime**: Netlify (Next.js runtime where supported) + Netlify Functions for server-side endpoints (including Stripe webhooks).
+- **Database provider**: PostgreSQL managed by **Neon** (hosted PostgreSQL) for production, with PostgreSQL compatible local development (ex. Docker) as a tooling choice.
+- **ORM/Migrations**: Prisma for data access and migrations.
+- **Auth**: NextAuth.js with a Prisma adapter for session persistence. The app will enforce roles *Guest/User/Premium/Admin** server-side. Premium is an **entitlement** derived from Stripe subscription state, not a static role assignment.
+
+### Consequences
+- Deployment config will include `netlify.toml` and documented env var names (no secrets committed).
+m Prisma schema must support roles and subscriptions and an idempotency ledger for Stripe webhooks.
+- Server-side gating must not rely on UI only for Premium features.
+
+---
+
+## Pending AD2s (not decided yet)
 > These are tracked here for visibility; they do **not** change scope without explicit approval.
 
-- Data store selection (SQL vs other) and hosting constraints under Netlify-only.
- - Locale routing strategy (path prefix vs other) and SEO canonical policy for fallbacks.
- - Observability strategy (logs/alerts) and webhook dead-letter handling.
+- Observability strategy (logs/alerts) and webhook dead-letter handling.


### PR DESCRIPTION
## Summary
Locks Sprint 1 stack decisions in canon ADRs: Netlify-only hosting, Next.js runtime + Functions, Postgres provider choice, Prisma ORM, and auth approach with role model (Guest/User/Premium/Admin).

## Files changed
- `docs/canon/ADR.md`

## Test plan (smoke)
- [ ] Open `docs/canon/ADR.md` in GitHub UI and verify ADR-0001 remains Netlify-only (Vercel forbidden)
- [ ] Verify ADR-0002 clearly states DB provider, Prisma, auth strategy, and role model

## Risks / edge cases
- DB provider choice is locked for S1 to unblock implementation; switching later would require a new ADR and migration plan.
- Premium is treated as an entitlement derived from subscription state; implementation must avoid hard-coding premium as a static role.

## Link to Issue
Closes #23