### PR TITLE
OPS-CI-VERIFY-002: Verify required check behavior after ruleset re-enable — closes #62

### DIFF
--- a/docs/ops/RELEASE_CHECKLIST.md
+++ b/docs/ops/RELEASE_CHECKLIST.md
@@ -3,11 +3,11 @@
 This project is **Netlify-only**. **Vercel is forbidden**.
 
 ## CI / Quality
-- [ ] Required check `CI / build` is green
-- [ ] `npm ci && npm run build` passes locally
+- [ ] Required check `CI / build (pull_request)`  is green (required)
+- [ ] `npm install && npm run build` passes locally
 
 ## No secrets in repo
-- [ ] No `.env` committed (only `.env.example` / docs)
+- [ ] No `.env` committed (only `.env.example` or docs)
 - [ ] All credentials stored in Netlify site settings only
 
 ## Smoke (MVP)


### PR DESCRIPTION
## Summary
Creates a docs-only change to validate that required check `CI / build (pull_request)` triggers on PR, completes, and allows squash-merge after ruleset re-enable.

## Files changed
- `docs/ops/RELEASE_CHECKLIST.md`

## Test plan (smoke)
- [ ] CI / build (pull_request) passed
- [ ] Confirm PR becomes mergeable after check success

## Risks / edge cases
- If check gets stuck in "Expected", ruleset may still have context mismatch.

## Link to Issue
Closes #62

## Discipline checks
- [ ] CI / build passed
- [x] No secrets added
- [x] Netlify-only confirmed
