### PR TITLE
S2-PROD-RUNTIME-014: Fix next-intl runtime config discovery on Netlify

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,10 @@
+import createNextIntlPlugin from 'next-intl/plugin';
+
+const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true
 };
-export default nextConfig;
+
+export default withNextIntl(nextConfig);


### PR DESCRIPTION
## Context
Production `/en` was crashing on Netlify with:

- `Couldn't find next-intl config file`
- digest `3983930186`

The repo already contains `i18n/request.ts`, but `next.config.mjs` was not wiring the `next-intl` plugin, so the runtime config could not be discovered correctly in production.

## Changes
- Update `next.config.mjs` to use `createNextIntlPlugin('./i18n/request.ts')`
- Export the wrapped Next config

## Acceptance
- `/en` no longer throws the `Couldn't find next-intl config file` runtime error on Netlify
- Production deploy completes and localized routes render

Sprint: 2