### PR TITLE
Sprint 4: surface planner shopping list aggregation and unit system

### DIFF
--- a/app/shopping-list/page.tsx
+++ b/app/shopping-list/page.tsx
@@ -1,30 +1,119 @@
 'use client';
 
 import Link from 'next/link';
-import {useEffect, useState, type FormEvent} from 'react';
+import { useEffect, useState, type FormEvent } from 'react';
 
-type Item = {id: string; text: string; pantry: boolean};
+type ManualItem = {
+  id: string;
+  text: string;
+  pantry: boolean;
+};
+
+type PlannerShoppingItem = {
+  ingredientKey: string;
+  displayName: string;
+  quantity: number;
+  unit: string;
+  sourceCount: number;
+};
+
+type PlannerShoppingList = {
+  unitSystem: 'metric' | 'imperial' | string;
+  items: PlannerShoppingItem[];
+};
+
+function startOfWeek(date: Date) {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  const day = copy.getDay();
+  const diff = day === 0 ? -6 : 1 - day;
+  copy.setDate(copy.getDate() + diff);
+  return copy;
+}
+
+function addDays(date: Date, days: number) {
+  const copy = new Date(date);
+  copy.setDate(copy.getDate() + days);
+  return copy;
+}
+
+function formatDate(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
 
 export default function ShoppingListPage() {
-  const [items, setItems] = useState<Item[]>([]);
+  const [items, setItems] = useState<ManualItem[]>([]);
   const [text, setText] = useState('');
   const [err, setErr] = useState<string | null>(null);
   const [linkReady, setLinkReady] = useState(false);
   const [loading, setLoading] = useState(true);
 
+  const [weekStart, setWeekStart] = useState(formatDate(startOfWeek(new Date())));
+  const [plannerList, setPlannerList] = useState<PlannerShoppingList | null>(null);
+  const [plannerLoading, setPlannerLoading] = useState(true);
+  const [plannerError, setPlannerError] = useState<string | null>(null);
+  const [plannerPremiumRequired, setPlannerPremiumRequired] = useState(false);
+  const [plannerAuthenticated, setPlannerAuthenticated] = useState(true);
+
   async function load() {
     setErr(null);
     setLoading(true);
     const res = await fetch('/api/shopping-list');
+
     if (!res.ok) {
       setErr('Please log in to view your shopping list.');
       setItems([]);
       setLoading(false);
       return;
     }
+
     const data = await res.json();
     setItems(data.items || []);
     setLoading(false);
+  }
+
+  async function loadPlannerAggregation(targetWeekStart: string) {
+    setPlannerLoading(true);
+    setPlannerError(null);
+    setPlannerPremiumRequired(false);
+    setPlannerAuthenticated(true);
+
+    try {
+      const res = await fetch(`/api/v1/planner/weeks/${targetWeekStart}/shopping-list`, {
+        cache: 'no-store',
+      });
+
+      const data = await res.json().catch(() => ({}));
+
+      if (res.ok) {
+        setPlannerList(data.shoppingList ?? null);
+        return;
+      }
+
+      setPlannerList(null);
+
+      if (res.status === 403) {
+        setPlannerPremiumRequired(true);
+        setPlannerError('Upgrade to Premium to unlock planner-based shopping aggregation.');
+        return;
+      }
+
+      if (res.status === 401 || res.status === 404) {
+        setPlannerAuthenticated(false);
+        setPlannerError('Log in to review your planner-linked shopping list.');
+        return;
+      }
+
+      setPlannerError('Unable to load planner shopping aggregation for this week.');
+    } catch {
+      setPlannerList(null);
+      setPlannerError('Network error while loading planner shopping aggregation.');
+    } finally {
+      setPlannerLoading(false);
+    }
   }
 
   useEffect(() => {
@@ -32,50 +121,128 @@ export default function ShoppingListPage() {
     void load();
   }, []);
 
+  useEffect(() => {
+    void loadPlannerAggregation(weekStart);
+  }, [weekStart]);
+
   async function addItem(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
     const res = await fetch('/api/shopping-list', {
       method: 'POST',
-      headers: {'content-type': 'application/json'},
-      body: JSON.stringify({text})
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ text }),
     });
+
     if (!res.ok) {
       setErr('Failed to add item (are you logged in?).');
       return;
     }
+
     setText('');
     await load();
   }
 
-  async function toggle(item: Item) {
+  async function toggle(item: ManualItem) {
     await fetch('/api/shopping-list', {
       method: 'PATCH',
-      headers: {'content-type': 'application/json'},
-      body: JSON.stringify({id: item.id, pantry: !item.pantry})
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: item.id, pantry: !item.pantry }),
     });
+
     await load();
   }
 
-  async function remove(item: Item) {
+  async function remove(item: ManualItem) {
     await fetch('/api/shopping-list', {
       method: 'DELETE',
-      headers: {'content-type': 'application/json'},
-      body: JSON.stringify({id: item.id})
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ id: item.id }),
     });
+
     await load();
+  }
+
+  function movePlannerWeek(days: number) {
+    setWeekStart((current) => formatDate(startOfWeek(addDays(new Date(current), days))));
   }
 
   const pantryCount = items.filter((item) => item.pantry).length;
+  const plannerItemCount = plannerList?.items?.length ?? 0;
 
   return (
     <div className="recipesPage">
       <div className="pageIntro">
         <h1>Shopping list</h1>
         <p>
-          Add ingredients from recipes or type items manually. Mark items as already at home with the
-          pantry toggle.
+          Add ingredients manually or review the planner-linked weekly aggregation. Unit continuity stays
+          aligned with your current preferences where planner aggregation is available.
         </p>
       </div>
+
+      <section className="panel">
+        <div className="plannerSidebarHeader">
+          <div>
+            <h2>Planner week aggregation</h2>
+            <p className="muted">Week of {weekStart}</p>
+          </div>
+          <div className="filterActions">
+            <button type="button" onClick={() => movePlannerWeek(-7)}>
+              Previous week
+            </button>
+            <button type="button" onClick={() => setWeekStart(formatDate(startOfWeek(new Date())))}>
+              This week
+            </button>
+            <button type="button" onClick={() => movePlannerWeek(7)}>
+              Next week
+            </button>
+          </div>
+        </div>
+
+        {plannerLoading ? <p>Loading planner shopping aggregation…</p> : null}
+        {plannerError ? <p className="statusError">{plannerError}</p> : null}
+
+        {plannerList ? (
+          <>
+            <p className="resultsMeta">
+              {plannerItemCount} aggregated item{plannerItemCount === 1 ? '' : 's'} • unit system:{' '}
+              {plannerList.unitSystem || 'metric'}
+            </p>
+            {plannerList.items.length ? (
+              <ul className="ingredientList">
+                {plannerList.items.map((item) => (
+                  <li key={item.ingredientKey}>
+                    <strong>{item.displayName}</strong>
+                    <span className="muted">
+                      {item.quantity} {item.unit} • {item.sourceCount} recipe{item.sourceCount === 1 ? '' : 's'}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <div className="emptyState">
+                <p>No planner meals for this week yet. Add meals in the planner to see aggregated ingredients.</p>
+                <div className="filterActions">
+                  <Link href="/planner">Open planner</Link>
+                </div>
+              </div>
+            )}
+          </>
+        ) : null}
+
+        {!plannerLoading && plannerPremiumRequired ? (
+          <div className="filterActions">
+            <Link href="/account">Upgrade to Premium</Link>
+            <Link href="/planner">Review planner</Link>
+          </div>
+        ) : null}
+
+        {!plannerLoading && !plannerAuthenticated ? (
+          <div className="filterActions">
+            <Link href="/account/login">Log in</Link>
+            <Link href="/account/register">Create an account</Link>
+          </div>
+        ) : null}
+      </section>
 
       {err ? (
         <div className="emptyState">
@@ -83,8 +250,7 @@ export default function ShoppingListPage() {
           {linkReady ? (
             <p>
               <Link href="/account/login">Log in</Link>{' '}or{' '}
-              <Link href="/account/register">create an account</Link>
-              {' '}to save your shopping list.
+              <Link href="/account/register">create an account</Link>{' '}to save your shopping list.
             </p>
           ) : null}
         </div>
@@ -118,7 +284,9 @@ export default function ShoppingListPage() {
                     <button type="button" onClick={() => toggle(item)}>
                       {item.pantry ? 'Mark as need to buy' : 'Mark as at home'}
                     </button>
-                    <button type="button" onClick={() => remove(item)}>Remove</button>
+                    <button type="button" onClick={() => remove(item)}>
+                      Remove
+                    </button>
                   </div>
                 </li>
               ))}


### PR DESCRIPTION
## Summary
Close the next visible Sprint 4 gap by surfacing planner week shopping list aggregation and metric/imperial continuity on the main shopping list page.

## What changed
- add a planner week shopping list panel to `/shopping-list`
- show the active unit system for planner aggregation
- support previous / current / next week navigation for planner aggregation
- preserve the existing manual shopping list CRUD flow
- handle Premium and unauthenticated planner aggregation states in the UI while keeping server-side enforcement intact

## Scope
- planner aggregation panel
- unit-system surfacing
- week navigation for aggregation
- gated-state UX handling

## Out of scope
- replacing the existing manual shopping list feature
- autoplan or recommendations
- pantry intelligence
- backend contract changes

## Acceptance criteria
- `/shopping-list` shows an aggregated planner shopping list panel for the selected week
- the panel shows the active unit system (`metric` or `imperial`)
- Premium-gated responses are handled with appropriate CTA states
- existing manual shopping list CRUD still works
- CI and Netlify remain green

Closes #160