### PR TITLE
Sprint 4: add release hardening exit-gate report

### DIFF
--- a/docs/release/sprint-4-exit-gate-report.md
+++ b/docs/release/sprint-4-exit-gate-report.md
@@ -1,0 +1,67 @@
+# Sprint 4 exit-gate report
+
+Related issue: #162
+
+Date: 2026-03-15
+Status: CONDITIONAL GO
+
+## Verdict
+
+Sprint 4 is feature-complete in repository scope and conditionally release-ready. The remaining gate is not a beta-sized feature group, but a final exit-gate verification layer for role paths, deploy smoke, and nonfunctional expectations.
+
+## Sprint 4 coverage
+
+- [G] Planner foundation merged (PR #136)
+- [G] Planner weekly calendar UX and interactive V1 flows merged (PR #153)
+- [G] Planner nutrient summary surfaced in V1 (PRO covered through planner week API + UI)
+- [G] Planner shopping list aggregation merged (API + planner upreview in PR #153, main shopping-list surface in PR #161)
+- [G] Metric/imperial continuity surfaced in planner shopping aggregation (PRK #161)
+- [G] Onboarding + preferences completion flow merged
+- [G] SEO V1 baseline merged, including detail-page metadata hardening (PR #157)
+- [G] Analytics V1 baseline merged (PR #155)
+- [G] Analytics planner interaction funnel merged (PR #159)
+
+## Sprint 4 exit-gate checklist
+
+- [G] Roles covered in product model: Guest / User / Premium / Admin
+- [G] Premium gating remains server-side on planner routes and APIs
+- [G] Planner surfaces week navigation, recipe search, add, remove, summary, and shopping preview
+- [G] Shopping-list page surfaces planner aggregation with unit system continuity
+- [G] Onboarding/preferences continuity present for planner and shopping-list experiences
+- [G] SEO V1 surfaces sitemap/robots, locale-root alternates, and detail-page metadata
+- [G] Analytics V1 surfaces planner view, paywall view, checkout start, and planner interaction milestones
+- [Y] Mobile-first smoke should be confirmed on deploy preview/prod by human device check
+- [Y] A11y quick-pass should be confirmed on deploy preview/prod (eyeball keyboard/focus/semantics)
+- [Y] Security smoke should be confirmed on deploy preview/prod for auth states and Premium denyals
+- [Y] Netlify preview/prod smoke confirmation should verify core Sprint 4 flows end-to-end
+
+## Smoke status by area
+
+- Planner / Premium gating: PASS IN REPOSITORY SCOPE
+- Shopping list / aggregation continuity: PASS IN REPOSITORY SCOPE
+- Onboarding / preferences: PASS in repository scope
+- SEO V1Z baseline: PASS in repository scope
+- Analytics V1Z baseline: PASS in repository scope
+- CI / build / Netlify PR checks: PASS on merged progression
+- Mobile / A11y quick pass: PENDING DEOLOY-TIME SMOKE
+- Security / access-control smoke: PENDING DEPLOY-TIME SMOKE
+
+- Stripe operational verification: OUT OF SCOPE FOR SPRINT 4 FEATURE CLOSURE, BUT STILL A DEPLOY-TIME GATE
+
+## Remaining reliable GO closure steps
+
+1. Confirm deploy preview/prod smoke for core Sprint 4 routes:
+   - `/planner` for Premium, and denial for non-Premium
+   - `/shopping-list` manual flow + planner aggregation panel
+   - ` account` + `onboarding` path continuity
+2. Confirm mobile layout and keyboard/focus baseline on deploy preview
+s
+ 3. Confirm non-Premium direct requests still cannot access Premium planner data
+ 4. If none of the above reveals a critical blocker, close #162 and mark Sprint 4 as CLOSED
+
+## No-GO if
+
+- non-Premium users can access Premium routes or data by direct request
+- Planner or shopping-list core Sprint 4 flows fail on deploy preview/prod
+- Analytics or SEO integration introduces breaking runtime errors
+- mobile/A11y checks find a severe core-task regression


### PR DESCRIPTION
## Summary
Add the formal Sprint 4 release-hardening / exit-gate artifact so Sprint 4 can be closed against a single repository-visible checklist instead of ad hoc status.

## What changed
- add `docs/release/sprint-4-exit-gate-report.md`
- capture Sprint 4 merged coverage across planner, shopping list, onboarding, SEO, and analytics
- define a pass/conditional-go/no-go style release verdict
- define the remaining deploy-time confirmation steps for formal Sprint 4 closure

## Scope
- release artifact only
- no feature changes
- no backend contract changes

## Out of scope
- new Sprint 4 features
- Sprint 5 work
- deploy-time smoke execution itself

## Acceptance criteria
- repo contains a single Sprint 4 exit-gate artifact
- artifact lists merged Sprint 4 coverage and remaining closure checks
- artifact makes Premium gating, SEO, analytics, mobile, A11y, and security expectations explicit
- CI and Netlify remain green

Closes #162