### PR TITLE
fix(v1): add localized onboarding route for planner setup CTA

### DIFF
--- a/app/[locale]/account/onboarding/page.tsx
+++ b/app/[locale]/account/onboarding/page.tsx
@@ -1,0 +1,1 @@
+export {default} from '../../../account/onboarding/page';


### PR DESCRIPTION
## Summary
- add `app/[locale]/account/onboarding/page.tsx`
- mirror the existing localized route pattern already used for `account/login` and `account/register`
- fix locale-prefixed setup/onboarding links so they do not hit a 404

## Why
Live verification showed that the planner/account setup CTA can point users to locale-prefixed onboarding routes such as `/en/account/onboarding`, but the localized onboarding route file was missing.

The root route existed:
- `app/account/onboarding/page.tsx`

Localized account routes also existed for:
- `app/[locale]/account/login/page.tsx`
- `app/[locale]/account/register/page.tsx`

But this one was missing:
- `app/[locale]/account/onboarding/page.tsx`

That mismatch caused an otherwise valid locale-aware link to land on a 404.

## Scope
In-scope:
- one localized onboarding route file

Out-of-scope:
- onboarding UX changes
- planner logic changes
- auth logic changes
- V2 work

## Validation intent
- `/en/account/onboarding` should resolve
- `/fr/account/onboarding` should resolve
- planner/account setup CTA should no longer 404

Closes #177